### PR TITLE
Add ability to inspect redis ratelimiters

### DIFF
--- a/redis/redis.go
+++ b/redis/redis.go
@@ -1,0 +1,22 @@
+package redis
+
+import "fmt"
+
+func parseRedisInt64Slice(v interface{}) ([]int64, error) {
+	args, ok := v.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("expected []interface{} but got %T", v)
+	}
+
+	out := make([]int64, len(args))
+	for i, arg := range args {
+		value, ok := arg.(int64)
+		if !ok {
+			return nil, fmt.Errorf("expected int64 in args[%d] but got %T", i, arg)
+		}
+
+		out[i] = value
+	}
+
+	return out, nil
+}

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -2,8 +2,10 @@ package redis
 
 import (
 	"context"
+	"testing"
 
 	"github.com/aidenwallis/go-ratelimiting/redis/adapters"
+	"github.com/stretchr/testify/assert"
 )
 
 type mockAdapter struct {
@@ -17,4 +19,38 @@ var _ adapters.Adapter = (*mockAdapter)(nil)
 func (a *mockAdapter) Eval(_ context.Context, _ string, _ []string, _ []interface{}) (interface{}, error) {
 	a.called = true
 	return a.returnValue, a.returnError
+}
+
+func TestParseRedisInt64Slice(t *testing.T) {
+	t.Run("errors", func(t *testing.T) {
+		testCases := map[string]struct {
+			errorMessage string
+			in           interface{}
+		}{
+			"invalid type": {
+				errorMessage: "expected []interface{} but got string",
+				in:           "foo",
+			},
+			"invalid value in slice": {
+				errorMessage: "expected int64 in args[1] but got string",
+				in:           []interface{}{int64(1), "two", int64(3)},
+			},
+		}
+
+		for name, testCase := range testCases {
+			testCase := testCase
+
+			t.Run(name, func(t *testing.T) {
+				out, err := parseRedisInt64Slice(testCase.in)
+				assert.Nil(t, out)
+				assert.EqualError(t, err, testCase.errorMessage)
+			})
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		out, err := parseRedisInt64Slice([]interface{}{int64(1), int64(2), int64(3)})
+		assert.NoError(t, err)
+		assert.Equal(t, []int64{1, 2, 3}, out)
+	})
 }


### PR DESCRIPTION
Inspecting ratelimits allows you to easily audit ratelimit usage without having to track per call, or increment to view the status of a bucket.